### PR TITLE
change AFHTTPRequestSerializer KVO manual notification

### DIFF
--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -288,7 +288,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFJSONResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFJSONResponseSerializer *serializer = [super copyWithZone:zone];
     serializer.readingOptions = self.readingOptions;
     serializer.removesKeysWithNullValues = self.removesKeysWithNullValues;
 
@@ -407,7 +407,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFXMLDocumentResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFXMLDocumentResponseSerializer *serializer = [super copyWithZone:zone];
     serializer.options = self.options;
 
     return serializer;
@@ -496,7 +496,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFPropertyListResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFPropertyListResponseSerializer *serializer = [super copyWithZone:zone];
     serializer.format = self.format;
     serializer.readOptions = self.readOptions;
 
@@ -722,7 +722,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFImageResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFImageResponseSerializer *serializer = [super copyWithZone:zone];
 
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
     serializer.imageScale = self.imageScale;
@@ -796,7 +796,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFCompoundResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    AFCompoundResponseSerializer *serializer = [super copyWithZone:zone];
     serializer.responseSerializers = self.responseSerializers;
 
     return serializer;

--- a/Tests/Tests/AFCompoundResponseSerializerTests.m
+++ b/Tests/Tests/AFCompoundResponseSerializerTests.m
@@ -64,12 +64,17 @@
     AFImageResponseSerializer *imageSerializer = [AFImageResponseSerializer serializer];
     AFJSONResponseSerializer *jsonSerializer = [AFJSONResponseSerializer serializer];
     AFCompoundResponseSerializer *compoundSerializer = [AFCompoundResponseSerializer compoundSerializerWithResponseSerializers:@[imageSerializer, jsonSerializer]];
+    [compoundSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+    [compoundSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
 
     AFCompoundResponseSerializer *copiedSerializer = [compoundSerializer copy];
+    XCTAssertNotNil(copiedSerializer);
     XCTAssertNotEqual(compoundSerializer, copiedSerializer);
     XCTAssertTrue(compoundSerializer.responseSerializers.count == copiedSerializer.responseSerializers.count);
     XCTAssertTrue([NSStringFromClass([[copiedSerializer.responseSerializers objectAtIndex:0] class]) isEqualToString:NSStringFromClass([AFImageResponseSerializer class])]);
     XCTAssertTrue([NSStringFromClass([[copiedSerializer.responseSerializers objectAtIndex:1] class]) isEqualToString:NSStringFromClass([AFJSONResponseSerializer class])]);
+    XCTAssertEqual(compoundSerializer.acceptableStatusCodes, copiedSerializer.acceptableStatusCodes);
+    XCTAssertEqual(compoundSerializer.acceptableContentTypes, copiedSerializer.acceptableContentTypes);
 }
 
 - (void)testCompoundSerializerCanBeArchivedAndUnarchived {

--- a/Tests/Tests/AFImageResponseSerializerTests.m
+++ b/Tests/Tests/AFImageResponseSerializerTests.m
@@ -33,11 +33,14 @@
 
 - (void)testImageSerializerCanBeCopied {
     AFImageResponseSerializer *responseSerializer = [AFImageResponseSerializer serializer];
+    [responseSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
+    [responseSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+
     AFImageResponseSerializer *copiedSerializer = [responseSerializer copy];
     XCTAssertNotNil(copiedSerializer);
     XCTAssertNotEqual(copiedSerializer, responseSerializer);
-    XCTAssertTrue([copiedSerializer.acceptableContentTypes isEqualToSet:responseSerializer.acceptableContentTypes]);
-    XCTAssertTrue([copiedSerializer.acceptableStatusCodes isEqualToIndexSet:responseSerializer.acceptableStatusCodes]);
+    XCTAssertEqual(copiedSerializer.acceptableContentTypes, responseSerializer.acceptableContentTypes);
+    XCTAssertEqual(copiedSerializer.acceptableStatusCodes, responseSerializer.acceptableStatusCodes);
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
     XCTAssertTrue(copiedSerializer.automaticallyInflatesResponseImage == responseSerializer.automaticallyInflatesResponseImage);
     XCTAssertTrue(fabs(copiedSerializer.imageScale - responseSerializer.imageScale) <= 0.001);

--- a/Tests/Tests/AFJSONSerializationTests.m
+++ b/Tests/Tests/AFJSONSerializationTests.m
@@ -168,4 +168,18 @@ static NSData * AFJSONTestData() {
     XCTAssertNil(responseObject[@"array"][0][@"subnullkey"]);
 }
 
+- (void)testThatJSONResponseSerializerCanBeCopied {
+    [self.responseSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+    [self.responseSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
+    [self.responseSerializer setReadingOptions:NSJSONReadingMutableLeaves];
+    [self.responseSerializer setRemovesKeysWithNullValues:YES];
+
+    AFJSONResponseSerializer *copiedSerializer = [self.responseSerializer copy];
+    XCTAssertNotEqual(copiedSerializer, self.responseSerializer);
+    XCTAssertEqual(copiedSerializer.acceptableStatusCodes, self.responseSerializer.acceptableStatusCodes);
+    XCTAssertEqual(copiedSerializer.acceptableContentTypes, self.responseSerializer.acceptableContentTypes);
+    XCTAssertEqual(copiedSerializer.readingOptions, self.responseSerializer.readingOptions);
+    XCTAssertEqual(copiedSerializer.removesKeysWithNullValues, self.responseSerializer.removesKeysWithNullValues);
+}
+
 @end

--- a/Tests/Tests/AFPropertyListResponseSerializerTests.m
+++ b/Tests/Tests/AFPropertyListResponseSerializerTests.m
@@ -46,11 +46,18 @@
 }
 
 - (void)testResponseSerializerCanBeCopied {
+    [self.responseSerializer setAcceptableContentTypes:[NSSet setWithObject:@"test/type"]];
+    [self.responseSerializer setAcceptableStatusCodes:[NSIndexSet indexSetWithIndex:100]];
+    [self.responseSerializer setFormat:NSPropertyListXMLFormat_v1_0];
+    [self.responseSerializer setReadOptions:NSPropertyListMutableContainers];
+
     AFPropertyListResponseSerializer *copiedSerializer = [self.responseSerializer copy];
     XCTAssertNotNil(copiedSerializer);
     XCTAssertNotEqual(copiedSerializer, self.responseSerializer);
-    XCTAssertTrue(copiedSerializer.format == self.responseSerializer.format);
-    XCTAssertTrue(copiedSerializer.readOptions == self.responseSerializer.readOptions);
+    XCTAssertEqual(copiedSerializer.format, self.responseSerializer.format);
+    XCTAssertEqual(copiedSerializer.readOptions, self.responseSerializer.readOptions);
+    XCTAssertEqual(copiedSerializer.acceptableContentTypes, self.responseSerializer.acceptableContentTypes);
+    XCTAssertEqual(copiedSerializer.acceptableStatusCodes, self.responseSerializer.acceptableStatusCodes);
 }
 
 - (void)testResponseSerializerCanBeArchivedAndUnarchived {


### PR DESCRIPTION
 //+ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
//    if ([AFHTTPRequestSerializerObservedKeyPaths() containsObject:key]) {
//        return NO;
//    }
//
//    return [super automaticallyNotifiesObserversForKey:key];
//}